### PR TITLE
Improved MultiMC support

### DIFF
--- a/env.go
+++ b/env.go
@@ -29,6 +29,7 @@ import (
 
 type envConsts struct {
 	MinecraftDir string
+	MultiMCDir   string
 	McdexDir     string
 	JavaDir      string
 }
@@ -37,24 +38,25 @@ var envData envConsts
 
 func initEnv() error {
 	// Get the minecraft directory, based on platform
-	mcDir := _minecraftDir()
+	mcDir := envData.MinecraftDir
+	if mcDir == "" {
+		mcDir = _minecraftDir()
+		envData.MinecraftDir = mcDir
+	}
 	os.Mkdir(mcDir, 0700)
 
 	// Get the mcdex directory, create if necessary
 	mcdexDir := filepath.Join(mcDir, "mcdex")
 	os.Mkdir(mcdexDir, 0700)
+	envData.McdexDir = mcdexDir
 
 	// Figure out where the JVM (and unpack200) commands can be found
 	javaDir := _findJavaDir(mcDir)
 	if javaDir == "" {
 		return fmt.Errorf("missing Java directory")
 	}
+	envData.JavaDir = javaDir
 
-	envData = envConsts{
-		MinecraftDir: mcDir,
-		McdexDir:     mcdexDir,
-		JavaDir:      javaDir,
-	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -147,15 +147,24 @@ func cmdPackCreate() error {
 	}
 
 	// Create the manifest for this new pack
-	err = cp.createManifest(dir, minecraftVsn, forgeVsn)
+	err = cp.createManifest(cp.name, minecraftVsn, forgeVsn)
 	if err != nil {
 		return err
 	}
 
-	// Create the launcher profile (and install forge if necessary)
-	err = cp.createLauncherProfile()
-	if err != nil {
-		return err
+	// If the -mmc flag is provided, don't create a launcher profile; just generate
+	// an instance.cfg for MultiMC to use
+	if ARG_MMC {
+		err = cp.generateMMCConfig()
+		if err != nil {
+			return err
+		}
+	} else {
+		// Create launcher profile
+		err = cp.createLauncherProfile()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/mmc.go
+++ b/mmc.go
@@ -49,10 +49,10 @@ func _mmcInstancesDir() (string, error) {
 
 func generateMMCConfig(pack *ModPack) error {
 	fmt.Printf("Generating instance.cfg for MultiMC\n")
-	cfg := fmt.Sprintf(MMC_CONFIG, pack.fullName())
-
-	// Write it out
-	if err := ioutil.WriteFile(filepath.Join(pack.rootPath, "instance.cfg"), []byte(cfg), 0644); err != nil {
+	instFile := filepath.Join(pack.rootPath, "instance.cfg")
+	if fileExists(instFile) {
+		fmt.Printf("  Already exists... Skipping\n")
+	} else if err := ioutil.WriteFile(instFile, []byte(fmt.Sprintf(MMC_CONFIG, pack.fullName())), 0644); err != nil {
 		return fmt.Errorf("failed to save instance.cfg: %+v", err)
 	}
 
@@ -71,7 +71,10 @@ func generateMMCConfig(pack *ModPack) error {
 	}, "components")
 	_, _ = mmcpack.Set(1, "formatVersion")
 
-	if err := writeJSON(mmcpack, filepath.Join(pack.rootPath, "mmc-pack.json")); err != nil {
+	packFile := filepath.Join(pack.rootPath, "mmc-pack.json")
+	if fileExists(packFile) {
+		fmt.Printf("  Already exists... Skipping\n")
+	} else if err := writeJSON(mmcpack, packFile); err != nil {
 		return fmt.Errorf("failed to save mmc-pack.json: %+v", err)
 	}
 

--- a/mmc.go
+++ b/mmc.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/Jeffail/gabs"
+)
+
+const MMC_CONFIG = `InstanceType=OneSix
+iconKey=flame
+name=%s
+`
+const InstanceDirKey = "InstanceDir="
+
+func _mmcInstancesDir() (string, error) {
+	// Default if not found in config file
+	dir := "instances"
+
+	if env().MultiMCDir == "" {
+		return "", errors.New("MultiMC directory is not set")
+	}
+
+	cfg, err := ioutil.ReadFile(filepath.Join(env().MultiMCDir, "multimc.cfg"))
+	if err != nil {
+		return "", err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(cfg)))
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, InstanceDirKey) {
+			dir = strings.TrimSpace(line[len(InstanceDirKey):])
+			break
+		}
+	}
+
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(env().MultiMCDir, dir)
+	}
+
+	return dir, err
+}
+
+func generateMMCConfig(pack *ModPack) error {
+	fmt.Printf("Generating instance.cfg for MultiMC\n")
+	cfg := fmt.Sprintf(MMC_CONFIG, pack.fullName())
+
+	// Write it out
+	if err := ioutil.WriteFile(filepath.Join(pack.rootPath, "instance.cfg"), []byte(cfg), 0644); err != nil {
+		return fmt.Errorf("failed to save instance.cfg: %+v", err)
+	}
+
+	minecraftVsn, forgeVsn := pack.getVersions()
+	fmt.Printf("Generating mmc-pack.json for MultiMC\n")
+	mmcpack := gabs.New()
+	_, _ = mmcpack.Array("components")
+	_ = mmcpack.ArrayAppend(map[string]interface{}{
+		"important": true,
+		"uid":       "net.minecraft",
+		"version":   minecraftVsn,
+	}, "components")
+	_ = mmcpack.ArrayAppend(map[string]interface{}{
+		"uid":     "net.minecraftforge",
+		"version": forgeVsn,
+	}, "components")
+	_, _ = mmcpack.Set(1, "formatVersion")
+
+	if err := writeJSON(mmcpack, filepath.Join(pack.rootPath, "mmc-pack.json")); err != nil {
+		return fmt.Errorf("failed to save mmc-pack.json: %+v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Greatly improved the MultiMC functionality. This should also close #29, which is similar to what prompted me to make these changes. I'm considering also adding an mcdex tool integration into MultiMC to allow performing pack management directly from MultiMC.

- Updated dependencies
- Fix MultiMC instance generation
- Support specifying non-default MC home directory
- Support using the pack name from the manifest during pack install
- Improved -mmc option to enable the following:
  - Look for MultiMC on system path or allow specifying from command line
  - Use MultiMC directory as MC home by default. Can be overridden from command line
  - Use the instance directory from the MultiMC config as the base pack path used to install/create/etc. mod packs
    - Pack create/install will create a valid instance immediately recognizable by MultiMC