### PR TITLE
Modify http client Dial() func to handle ipv6

### DIFF
--- a/util.go
+++ b/util.go
@@ -47,7 +47,7 @@ func NewHttpClient(followRedirects bool) http.Client {
 		Dial: func(network string, address string) (net.Conn, error) {
 			separator := strings.LastIndex(address, ":")
 			ip, _ := resolver.FetchOneString(address[:separator])
-			return net.Dial("tcp", ip+address[separator:])
+			return net.Dial("tcp", fmt.Sprintf("[%s]%s", ip, address[separator:]))
 		},
 	}
 

--- a/util.go
+++ b/util.go
@@ -47,7 +47,13 @@ func NewHttpClient(followRedirects bool) http.Client {
 		Dial: func(network string, address string) (net.Conn, error) {
 			separator := strings.LastIndex(address, ":")
 			ip, _ := resolver.FetchOneString(address[:separator])
-			return net.Dial("tcp", fmt.Sprintf("[%s]%s", ip, address[separator:]))
+			var ipWithPort string
+			if (strings.Contains(ip, ":")) {
+				ipWithPort = fmt.Sprintf("[%s]%s", ip, address[separator:])
+			} else {
+				ipWithPort = ip + address[separator:]
+			}
+			return net.Dial("tcp", ipWithPort)
 		},
 	}
 


### PR DESCRIPTION
I started getting this error running `mcdex pack.install`:
```
2019/06/10 20:27:43 failed to resolve project 262692: 
  HTTP error on https://minecraft.curseforge.com/projects/262692?cookieTest=1: 
  Get https://minecraft.curseforge.com/projects/262692?cookieTest=1: 
  dial tcp: address 2606:4700::6813:9284:443: too many colons in address
```

It looked like I was getting ipv6 addresses. Some poking around and I found [this](https://socketloop.com/tutorials/golang-dial-tcp-too-many-colons-in-address) which suggested to put the address in brackets. Looks like it fixes the problem!