### PR TITLE
Only look up slug on download fail

### DIFF
--- a/curseforge_file.go
+++ b/curseforge_file.go
@@ -87,16 +87,15 @@ func (f CurseForgeModFile) install(pack *ModPack) error {
 		pack.modCache.CleanupModFile(f.projectID)
 	}
 
-	// Resolve the project ID into a slug
-	slug, err := pack.db.findSlugByProject(f.projectID)
-	if err != nil {
-		return fmt.Errorf("failed to find slug for project %d: %+v", f.projectID, err)
-	}
-
 	// Now, retrieve the JSON descriptor for this file so we can get the CDN url
 	descriptorUrl := fmt.Sprintf("https://addons-ecs.forgesvc.net/api/v2/addon/%d/file/%d", f.projectID, f.fileID)
 	descriptor, err := getJSONFromURL(descriptorUrl)
 	if err != nil {
+		// Resolve the project ID into a slug
+		slug, err2 := pack.db.findSlugByProject(f.projectID)
+		if err2 != nil {
+			return fmt.Errorf("failed to find slug and download url for project %d: %+v\n%+v", f.projectID, err, err2)
+		}
 		return fmt.Errorf("failed to retrieve descriptor for %s: %+v", slug, err)
 	}
 


### PR DESCRIPTION
Fixes #59 

Currently when installing a modpack, before downloading the mod files it tries to obtain the slug.
The only place this slug is then used is if it fails to find the download URL.
To actually obtain the download URL, it uses the project ID and file ID provided by the modpack manifest. There is no need for the slug at all.

This causes the installation of a modpack to fail if the mod is not yet in the database, even though if it didn't look up the slug it would be able to determine the download URL and successfully install the modpack.